### PR TITLE
Fix TypeScript configuration for frontend

### DIFF
--- a/students-platform/frontend/tsconfig.app.json
+++ b/students-platform/frontend/tsconfig.app.json
@@ -2,16 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "noUncheckedSideEffectImports": true,
-    "target": "es5",
-    "module": "commonjs"
+    "composite": true,
+    "noUncheckedSideEffectImports": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/students-platform/frontend/tsconfig.base.json
+++ b/students-platform/frontend/tsconfig.base.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "preserve",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}


### PR DESCRIPTION
- Add missing tsconfig.base.json with proper Vue/Vite compiler options
- Update tsconfig.app.json to extend base config and include .vue files
- Remove redundant compiler options that are now inherited from base
- Resolve Vite dependency scan error caused by missing base config