### PR TITLE
Add cascade deletion for notifications and cleanup script

### DIFF
--- a/students-platform/backend/package.json
+++ b/students-platform/backend/package.json
@@ -10,7 +10,8 @@
     "test:unit": "jest",
     "test:unit:watch": "jest --watch",
     "test:unit:coverage": "jest --coverage",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "cleanup:notifications": "ts-node src/scripts/cleanup-orphaned-notifications.ts"
   },
   "keywords": [],
   "author": "",

--- a/students-platform/backend/src/modules/comment/models/comment.model.ts
+++ b/students-platform/backend/src/modules/comment/models/comment.model.ts
@@ -24,5 +24,17 @@ export type CommentDoc = HydratedDocument<Comment>;
 
 CommentSchema.index({ createdAt: 1 });
 
+CommentSchema.pre('deleteOne', { document: true, query: false }, async function() {
+  const NotificationModel = model('Notification');
+  await NotificationModel.deleteMany({ target: this._id, targetModel: 'Comment' });
+});
+
+CommentSchema.pre('findOneAndDelete', async function() {
+  const doc = await this.model.findOne(this.getQuery());
+  if (doc) {
+    const NotificationModel = model('Notification');
+    await NotificationModel.deleteMany({ target: doc._id, targetModel: 'Comment' });
+  }
+});
 
 export const CommentModel: Model<Comment> = model<Comment>('Comment', CommentSchema);

--- a/students-platform/backend/src/modules/community/models/community-invitation.model.ts
+++ b/students-platform/backend/src/modules/community/models/community-invitation.model.ts
@@ -36,6 +36,19 @@ CommunityInvitationSchema.index({ recipientUser: 1, status: 1 });
 CommunityInvitationSchema.index({ recipientEmail: 1, status: 1 });
 CommunityInvitationSchema.index({ expiresAt: 1 });
 
+CommunityInvitationSchema.pre('deleteOne', { document: true, query: false }, async function() {
+  const NotificationModel = model('Notification');
+  await NotificationModel.deleteMany({ target: this._id, targetModel: 'CommunityInvitation' });
+});
+
+CommunityInvitationSchema.pre('findOneAndDelete', async function() {
+  const doc = await this.model.findOne(this.getQuery());
+  if (doc) {
+    const NotificationModel = model('Notification');
+    await NotificationModel.deleteMany({ target: doc._id, targetModel: 'CommunityInvitation' });
+  }
+});
+
 export const CommunityInvitationModel: Model<CommunityInvitation> = model<CommunityInvitation>(
   'CommunityInvitation',
   CommunityInvitationSchema

--- a/students-platform/backend/src/modules/community/models/community-join-request.model.ts
+++ b/students-platform/backend/src/modules/community/models/community-join-request.model.ts
@@ -30,6 +30,19 @@ export type CommunityJoinRequestDoc = HydratedDocument<CommunityJoinRequest>;
 CommunityJoinRequestSchema.index({ community: 1, status: 1 });
 CommunityJoinRequestSchema.index({ user: 1, community: 1 }, { unique: true });
 
+CommunityJoinRequestSchema.pre('deleteOne', { document: true, query: false }, async function() {
+  const NotificationModel = model('Notification');
+  await NotificationModel.deleteMany({ target: this._id, targetModel: 'CommunityJoinRequest' });
+});
+
+CommunityJoinRequestSchema.pre('findOneAndDelete', async function() {
+  const doc = await this.model.findOne(this.getQuery());
+  if (doc) {
+    const NotificationModel = model('Notification');
+    await NotificationModel.deleteMany({ target: doc._id, targetModel: 'CommunityJoinRequest' });
+  }
+});
+
 export const CommunityJoinRequestModel: Model<CommunityJoinRequest> = model<CommunityJoinRequest>(
   'CommunityJoinRequest',
   CommunityJoinRequestSchema

--- a/students-platform/backend/src/modules/community/models/community.model.ts
+++ b/students-platform/backend/src/modules/community/models/community.model.ts
@@ -49,4 +49,17 @@ CommunitySchema.index({ category: 1, isActive: 1, _id: -1 });
 CommunitySchema.index({ 'members.user': 1 });
 CommunitySchema.index({ isActive: 1, memberCount: -1 });
 
+CommunitySchema.pre('deleteOne', { document: true, query: false }, async function() {
+  const NotificationModel = model('Notification');
+  await NotificationModel.deleteMany({ target: this._id, targetModel: 'Community' });
+});
+
+CommunitySchema.pre('findOneAndDelete', async function() {
+  const doc = await this.model.findOne(this.getQuery());
+  if (doc) {
+    const NotificationModel = model('Notification');
+    await NotificationModel.deleteMany({ target: doc._id, targetModel: 'Community' });
+  }
+});
+
 export const CommunityModel: Model<Community> = model<Community>('Community', CommunitySchema);

--- a/students-platform/backend/src/modules/post/models/post.model.ts
+++ b/students-platform/backend/src/modules/post/models/post.model.ts
@@ -54,11 +54,23 @@ const PostSchema = new Schema(
 export type Post = InferSchemaType<typeof PostSchema>;
 export type PostDoc = HydratedDocument<Post>;
 
-PostSchema.index({ slug: 1 });
 PostSchema.index({ status: 1, visibility: 1, _id: -1 });
 PostSchema.index({ author: 1, _id: -1 });
 PostSchema.index({ category: 1, status: 1, visibility: 1, _id: -1 });
 PostSchema.index({ community: 1, status: 1, visibility: 1, _id: -1 });
 PostSchema.index({ community: 1, isPinned: -1, _id: -1 });
+
+PostSchema.pre('deleteOne', { document: true, query: false }, async function() {
+  const NotificationModel = model('Notification');
+  await NotificationModel.deleteMany({ target: this._id, targetModel: 'Post' });
+});
+
+PostSchema.pre('findOneAndDelete', async function() {
+  const doc = await this.model.findOne(this.getQuery());
+  if (doc) {
+    const NotificationModel = model('Notification');
+    await NotificationModel.deleteMany({ target: doc._id, targetModel: 'Post' });
+  }
+});
 
 export const PostModel: Model<Post> = model<Post>('Post', PostSchema);

--- a/students-platform/backend/src/scripts/cleanup-orphaned-notifications.ts
+++ b/students-platform/backend/src/scripts/cleanup-orphaned-notifications.ts
@@ -1,0 +1,110 @@
+import mongoose from 'mongoose';
+import { NotificationModel } from '../modules/notification/models/notification.model';
+import { PostModel } from '../modules/post/models/post.model';
+import { CommentModel } from '../modules/comment/models/comment.model';
+import { CommunityModel } from '../modules/community/models/community.model';
+import { CommunityInvitationModel } from '../modules/community/models/community-invitation.model';
+import { CommunityJoinRequestModel } from '../modules/community/models/community-join-request.model';
+import { db } from '../config/db';
+
+async function cleanupOrphanedNotifications() {
+  try {
+    console.log('🧹 Starting orphaned notifications cleanup...\n');
+
+    await db.connect();
+    console.log('✅ Connected to database\n');
+
+    const notifications = await NotificationModel.find({})
+      .select('_id target targetModel')
+      .lean();
+
+    console.log(`📊 Total notifications in database: ${notifications.length}\n`);
+
+    let deletedCount = 0;
+    const orphanedIds: mongoose.Types.ObjectId[] = [];
+
+    console.log('🔍 Checking for orphaned notifications...\n');
+
+    for (const notification of notifications) {
+      let targetExists = false;
+
+      try {
+        switch (notification.targetModel) {
+          case 'Post':
+            targetExists = await PostModel.exists({ _id: notification.target }) !== null;
+            break;
+          case 'Comment':
+            targetExists = await CommentModel.exists({ _id: notification.target }) !== null;
+            break;
+          case 'Community':
+            targetExists = await CommunityModel.exists({ _id: notification.target }) !== null;
+            break;
+          case 'CommunityInvitation':
+            targetExists = await CommunityInvitationModel.exists({ _id: notification.target }) !== null;
+            break;
+          case 'CommunityJoinRequest':
+            targetExists = await CommunityJoinRequestModel.exists({ _id: notification.target }) !== null;
+            break;
+          case 'User':
+          case 'Message':
+            // Skip User and Message for now as they might be in different collections
+            targetExists = true;
+            break;
+          default:
+            console.warn(`⚠️  Unknown targetModel: ${notification.targetModel}`);
+            targetExists = true;
+        }
+
+        if (!targetExists) {
+          console.log(`🗑️  Found orphaned notification: ${notification._id} (target: ${notification.target}, model: ${notification.targetModel})`);
+          orphanedIds.push(notification._id);
+        }
+      } catch (error: any) {
+        console.error(`❌ Error checking notification ${notification._id}:`, error.message);
+      }
+    }
+
+    if (orphanedIds.length === 0) {
+      console.log('\n✅ No orphaned notifications found. Database is clean!\n');
+    } else {
+      console.log(`\n📊 Found ${orphanedIds.length} orphaned notifications\n`);
+      console.log('🗑️  Deleting orphaned notifications...');
+
+      const result = await NotificationModel.deleteMany({ _id: { $in: orphanedIds } });
+      deletedCount = result.deletedCount || 0;
+
+      console.log(`✅ Deleted ${deletedCount} orphaned notifications\n`);
+    }
+
+    console.log('📊 Cleanup Summary:');
+    console.log(`   Total checked:      ${notifications.length}`);
+    console.log(`   Orphaned found:     ${orphanedIds.length}`);
+    console.log(`   Successfully deleted: ${deletedCount}\n`);
+
+    if (deletedCount > 0) {
+      console.log('✨ Cleanup completed successfully!\n');
+    }
+
+  } catch (error: any) {
+    console.error('\n❌ Cleanup failed:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+  } finally {
+    await db.disconnect();
+    console.log('👋 Disconnected from database');
+  }
+}
+
+if (require.main === module) {
+  cleanupOrphanedNotifications()
+    .then(() => {
+      console.log('\n✅ Script completed successfully');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('\n❌ Script failed:', error);
+      process.exit(1);
+    });
+}
+
+export { cleanupOrphanedNotifications };


### PR DESCRIPTION
- Implement cascade deletion hooks in Post, Community, Comment, CommunityInvitation, and CommunityJoinRequest models to automatically delete related notifications
- Add cleanup script to remove orphaned notifications from database
- Fix duplicate slug index in Post model
- Add npm script for running notification cleanup